### PR TITLE
sapphire support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ./
         with:
           gh-pat: ${{ secrets.GH_PAT }} 
+          cli: nightly
           # sdk: nightly
           build-config: RelWithDebInfo
           path: textureldr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: geode-catgirls/nyaaldr
+          repository: geode-sdk/textureldr
           path: textureldr
 
       - name: Build the mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build the mod
         uses: ./
         with:
-          gh-pat: ${{ secrets.GH_PAT }} 
           cli: nightly
           # sdk: nightly
           build-config: RelWithDebInfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
           os: windows-latest
         - name: macOS
           os: macos-latest
+        #- name: iOS
+        #  os: macos-latest
+        #  target: iOS
         - name: Android32
           os: ubuntu-latest
           target: Android32

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
           os: windows-latest
         - name: macOS
           os: macos-latest
-        #- name: iOS
-        #  os: macos-latest
-        #  target: iOS
+        - name: iOS
+          os: macos-latest
+          target: iOS
         - name: Android32
           os: ubuntu-latest
           target: Android32
@@ -34,12 +34,13 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: geode-sdk/textureldr
+          repository: geode-catgirls/nyaaldr
           path: textureldr
 
       - name: Build the mod
         uses: ./
         with:
+          gh-pat: ${{ secrets.GH_PAT }} 
           # sdk: nightly
           build-config: RelWithDebInfo
           path: textureldr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./
         with:
           cli: nightly
-          # sdk: nightly
+          sdk: nightly
           build-config: RelWithDebInfo
           path: textureldr
           combine: true

--- a/action.yml
+++ b/action.yml
@@ -205,16 +205,7 @@ runs:
         mkdir -p "$CLI_PROFILE/Contents/geode/mods"
         geode profile add --name GithubActions "$CLI_PROFILE/GeometryDash.exe" win
 
-        if [ "${{ steps.platform.outputs.target_id }}" != "ios" ]; then
-          geode sdk install "${{ github.workspace }}/geode-sdk-clone"
-        else
-          echo "cloning ios geode"
-          git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
-          mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
-          dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases -H "Authorization: Bearer ${{ github.token }}" | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
-          echo "nightly dl url: $dl_url"
-          curl -L "$dl_url" -o "geode-ios.zip" && unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly" && rm "geode-ios.zip"
-        fi
+        geode sdk install "${{ github.workspace }}/geode-sdk-clone"
 
         # silly github actions wont refresh the env
         export GEODE_SDK="${{ github.workspace }}/geode-sdk-clone"

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,7 @@ runs:
         repository: geode-catgirls/geode
         tag: nightly
         filename: geode-*-ios.zip
-        out-file-path: ${{ github.workspace }}/geode-sdk-clone/bin/nightly
+        out-file-path: ${{ github.workspace }}/nightly-bin
         extract: true
 
     - name: Setup Geode SDK
@@ -220,6 +220,8 @@ runs:
         else
           echo "cloning diff geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
+          mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
+          mv "${{ github.workspace }}/nightly-bin" "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
         fi
 
         # silly github actions wont refresh the env

--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,7 @@ runs:
           echo "cloning diff geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
-          mv "${{ github.workspace }}/nightly-bin" "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
+          mv "${{ github.workspace }}/nightly-bin/*" "${{ github.workspace }}/geode-sdk-clone/bin/nightly/"
         fi
 
         # silly github actions wont refresh the env

--- a/action.yml
+++ b/action.yml
@@ -195,16 +195,6 @@ runs:
       with:
         version: ${{ inputs.cli }}
 
-    - name: Download binaries
-      if: steps.platform.outputs.target_id == 'ios'
-      uses: robinraju/release-downloader@v1
-      with:
-        repository: geode-catgirls/geode
-        tag: nightly
-        filename: geode-*-ios.zip
-        out-file-path: ${{ github.workspace }}/nightly-bin
-        extract: true
-
     - name: Setup Geode SDK
       shell: bash
       run: |
@@ -221,8 +211,12 @@ runs:
           echo "cloning diff geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
-          ls "${{ github.workspace }}/nightly-bin"
-          mv "${{ github.workspace }}/nightly-bin" "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
+          # dl nightly release binaries
+          releases=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases)
+          dl_url=$(echo "$releases" | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
+          echo "nightly dl url: $dl_url"
+          curl -L "$dl_url" -o "geode-ios.zip"
+          unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
         fi
 
         # silly github actions wont refresh the env

--- a/action.yml
+++ b/action.yml
@@ -242,21 +242,15 @@ runs:
           export TARGET_GEODE_VERSION=$(jq -r '.geode' $MOD_JSON_PATH)
           echo "Updating to version $TARGET_GEODE_VERSION from $MOD_JSON_PATH"
 
+          # remove this if clause after geode ios releases upstream
           if [ "${{ steps.platform.outputs.target_id }}" == "ios" ]; then
-            echo "!! WARNING !!"
-            echo "building against NIGHTLY as WORKAROUND"
-            echo "doin ios stuff and already installed meow meow, editing geode cli config"
-            echo "Old Config: $(cat /Users/Shared/Geode/config.json)"
+            echo "!! WARNING !! - building against NIGHTLY as WORKAROUND"
             echo $(cat /Users/Shared/Geode/config.json | jq '."sdk-nightly" = true | ."sdk-version" = null') > /Users/Shared/Geode/config.json
-            echo "New Config: $(cat /Users/Shared/Geode/config.json)"
           else
-            geode sdk update nightly
-            geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
+            geode sdk update "$TARGET_GEODE_VERSION"
+            geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"
           fi
 
-          #uncomment these when geode ios releases:
-          # geode sdk update "$TARGET_GEODE_VERSION"
-          # geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"
         else
           geode sdk update ${{ inputs.sdk }}
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}

--- a/action.yml
+++ b/action.yml
@@ -286,7 +286,7 @@ runs:
         elif [ ${{ steps.platform.outputs.target_id }} = "android64" ]; then
           CMAKE_EXTRA_ARGS="-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_shared -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-${{ inputs.android-min-sdk }}"
         elif [ ${{ steps.platform.outputs.target_id }} = "ios" ]; then
-          CMAKE_EXTRA_ARGS="-DCMAKE_SYSTEM_NAME=iOS -DGEODE_TARGET_PLATFORM=iOS"
+          CMAKE_EXTRA_ARGS="-DCMAKE_SYSTEM_NAME=iOS -DGEODE_TARGET_PLATFORM=iOS -DGEODE_DISABLE_PRECOMPILED_HEADERS=OFF"
         fi
         if [ "${{ inputs.use-lto }}" = "true" ]; then
           CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"

--- a/action.yml
+++ b/action.yml
@@ -211,8 +211,7 @@ runs:
         export GEODE_SDK="${{ github.workspace }}/geode-sdk-clone"
         echo "GEODE_SDK=$GEODE_SDK" >> $GITHUB_ENV
 
-        if [ "${{ inputs.sdk }}" == "nightly" ] || [ "${{ steps.platform.outputs.target_id }}" == "ios" ]; then
-          [ "${{ steps.platform.outputs.target_id }}" == "ios" ] && echo "WARNING - building for NIGHTLY as workaround!!"
+        if [ "${{ inputs.sdk }}" == "nightly" ]; then
           geode sdk update nightly
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
         elif [ "${{ inputs.sdk }}" == "latest" ]; then

--- a/action.yml
+++ b/action.yml
@@ -208,15 +208,12 @@ runs:
         if [ "${{ steps.platform.outputs.target_id }}" != "ios" ]; then
           geode sdk install "${{ github.workspace }}/geode-sdk-clone"
         else
-          echo "cloning diff geode"
+          echo "cloning ios geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
-          # dl nightly release binaries
-          releases=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases)
-          dl_url=$(echo "$releases" | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
+          dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
           echo "nightly dl url: $dl_url"
-          curl -L "$dl_url" -o "geode-ios.zip"
-          unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
+          curl -L "$dl_url" -o "geode-ios.zip" && unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly" && rm "geode-ios.zip"
         fi
 
         # silly github actions wont refresh the env

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,8 @@ runs:
           # remove this if clause after geode ios releases upstream
           if [ "${{ steps.platform.outputs.target_id }}" == "ios" ]; then
             echo "!! WARNING !! - building against NIGHTLY as WORKAROUND"
-            echo $(cat /Users/Shared/Geode/config.json | jq '."sdk-nightly" = true | ."sdk-version" = null') > /Users/Shared/Geode/config.json
+            geode sdk update nightly
+            geode sdk install-binaries --platform ios
           else
             geode sdk update "$TARGET_GEODE_VERSION"
             geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -62,10 +62,6 @@ inputs:
     description: Whether to use LTO (Link Time Optimization) via the CMAKE_INTERPROCEDURAL_OPTIMIZATION flag, improving build size. Defaults to true
     required: false
     default: true
-  gh-pat:
-    description: GitHub personal access token for downloading stuffs
-    required: false
-    default: ""
 
 outputs:
   build-output:
@@ -203,8 +199,7 @@ runs:
       if: steps.platform.outputs.target_id == 'ios'
       uses: actions/checkout@v4
       with:
-        repository: geode-catgirls/geode-cgs
-        token: ${{ inputs.gh-pat }}
+        repository: geode-catgirls/geode
         ref: nightly
         path: geode-sdk-clone
 
@@ -212,8 +207,7 @@ runs:
       if: steps.platform.outputs.target_id == 'ios'
       uses: robinraju/release-downloader@v1
       with:
-        repository: geode-catgirls/geode-cgs
-        token: ${{ inputs.gh-pat }}
+        repository: geode-catgirls/geode
         tag: nightly
         filename: geode-*-ios.zip
         out-file-path: ${{ github.workspace }}/geode-sdk-clone/bin/nightly
@@ -267,7 +261,7 @@ runs:
           geode sdk update ${{ inputs.sdk }}
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
         fi
-
+        
         export CPM_CACHE="${{ github.workspace }}/cpm-cache"
         echo "CPM_SOURCE_CACHE=$CPM_CACHE" >> $GITHUB_ENV
 

--- a/action.yml
+++ b/action.yml
@@ -211,9 +211,7 @@ runs:
           echo "cloning ios geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
-          stupid=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[]')
-          echo "$stupid"
-          dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
+          dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases -H "Authorization: Bearer ${{ github.token }}" | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
           echo "nightly dl url: $dl_url"
           curl -L "$dl_url" -o "geode-ios.zip" && unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly" && rm "geode-ios.zip"
         fi

--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,8 @@ runs:
         export GEODE_SDK="${{ github.workspace }}/geode-sdk-clone"
         echo "GEODE_SDK=$GEODE_SDK" >> $GITHUB_ENV
 
-        if [ "${{ inputs.sdk }}" == "nightly" ]; then
+        if [ "${{ inputs.sdk }}" == "nightly" ] || [ "${{ steps.platform.outputs.target_id }}" == "ios" ]; then
+          [ "${{ steps.platform.outputs.target_id }}" == "ios" ] && echo "WARNING - building for NIGHTLY as workaround!!"
           geode sdk update nightly
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
         elif [ "${{ inputs.sdk }}" == "latest" ]; then
@@ -221,17 +222,8 @@ runs:
           export MOD_JSON_PATH=$(find . -name "mod.json" -not -path "./geode-sdk-clone/*" -print | sort -r | head -n 1)
           export TARGET_GEODE_VERSION=$(jq -r '.geode' $MOD_JSON_PATH)
           echo "Updating to version $TARGET_GEODE_VERSION from $MOD_JSON_PATH"
-
-          # remove this if clause after geode ios releases upstream
-          if [ "${{ steps.platform.outputs.target_id }}" == "ios" ]; then
-            echo "!! WARNING !! - building against NIGHTLY as WORKAROUND"
-            geode sdk update nightly
-            geode sdk install-binaries --platform ios
-          else
-            geode sdk update "$TARGET_GEODE_VERSION"
-            geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"
-          fi
-
+          geode sdk update "$TARGET_GEODE_VERSION"
+          geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"
         else
           geode sdk update ${{ inputs.sdk }}
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: false
     default: false
   target:
-    description: Geode target to build for. Can be either "Win64", "MacOS", "Android32" or "Android64".
+    description: Geode target to build for. Can be either "Win64", "MacOS", "iOS", "Android32" or "Android64".
     required: false
     default: ""
   bindings:
@@ -62,6 +62,10 @@ inputs:
     description: Whether to use LTO (Link Time Optimization) via the CMAKE_INTERPROCEDURAL_OPTIMIZATION flag, improving build size. Defaults to true
     required: false
     default: true
+  gh-pat:
+    description: GitHub personal access token for downloading stuffs
+    required: false
+    default: ""
 
 outputs:
   build-output:
@@ -100,6 +104,8 @@ runs:
           OUTPUT_ID=win
         elif [ "$TARGET" = "MacOS" ]; then
           OUTPUT_ID=mac
+        elif [ "$TARGET" = "iOS" ]; then
+          OUTPUT_ID=ios
         fi
 
         echo "id=$ID" >> $GITHUB_OUTPUT
@@ -193,6 +199,26 @@ runs:
       with:
         version: ${{ inputs.cli }}
 
+    - name: Download Geode SDK
+      if: steps.platform.outputs.target_id == 'ios'
+      uses: actions/checkout@v4
+      with:
+        repository: geode-catgirls/geode-cgs
+        token: ${{ inputs.gh-pat }}
+        ref: nightly
+        path: geode-sdk-clone
+
+    - name: Download binaries
+      if: steps.platform.outputs.target_id == 'ios'
+      uses: robinraju/release-downloader@v1
+      with:
+        repository: geode-catgirls/geode-cgs
+        token: ${{ inputs.gh-pat }}
+        tag: nightly
+        filename: geode-*-ios.zip
+        out-file-path: ${{ github.workspace }}/geode-sdk-clone/bin/nightly
+        extract: true
+
     - name: Setup Geode SDK
       shell: bash
       run: |
@@ -203,7 +229,9 @@ runs:
         mkdir -p "$CLI_PROFILE/Contents/geode/mods"
         geode profile add --name GithubActions "$CLI_PROFILE/GeometryDash.exe" win
 
-        geode sdk install "${{ github.workspace }}/geode-sdk-clone"
+        if [ "${{ steps.platform.outputs.target_id }}" != "ios" ]; then
+          geode sdk install "${{ github.workspace }}/geode-sdk-clone"
+        fi
 
         # silly github actions wont refresh the env
         export GEODE_SDK="${{ github.workspace }}/geode-sdk-clone"
@@ -219,13 +247,27 @@ runs:
           export MOD_JSON_PATH=$(find . -name "mod.json" -not -path "./geode-sdk-clone/*" -print | sort -r | head -n 1)
           export TARGET_GEODE_VERSION=$(jq -r '.geode' $MOD_JSON_PATH)
           echo "Updating to version $TARGET_GEODE_VERSION from $MOD_JSON_PATH"
-          geode sdk update "$TARGET_GEODE_VERSION"
-          geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"
+
+          if [ "${{ steps.platform.outputs.target_id }}" == "ios" ]; then
+            echo "!! WARNING !!"
+            echo "building against NIGHTLY as WORKAROUND"
+            echo "doin ios stuff and already installed meow meow, editing geode cli config"
+            echo "Old Config: $(cat /Users/Shared/Geode/config.json)"
+            echo $(cat /Users/Shared/Geode/config.json | jq '."sdk-nightly" = true | ."sdk-version" = null') > /Users/Shared/Geode/config.json
+            echo "New Config: $(cat /Users/Shared/Geode/config.json)"
+          else
+            geode sdk update nightly
+            geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
+          fi
+
+          #uncomment these when geode ios releases:
+          # geode sdk update "$TARGET_GEODE_VERSION"
+          # geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }} --version "$TARGET_GEODE_VERSION"
         else
           geode sdk update ${{ inputs.sdk }}
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
         fi
-        
+
         export CPM_CACHE="${{ github.workspace }}/cpm-cache"
         echo "CPM_SOURCE_CACHE=$CPM_CACHE" >> $GITHUB_ENV
 
@@ -243,6 +285,8 @@ runs:
           CMAKE_EXTRA_ARGS="-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_shared -DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=android-${{ inputs.android-min-sdk }}"
         elif [ ${{ steps.platform.outputs.target_id }} = "android64" ]; then
           CMAKE_EXTRA_ARGS="-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_shared -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-${{ inputs.android-min-sdk }}"
+        elif [ ${{ steps.platform.outputs.target_id }} = "ios" ]; then
+          CMAKE_EXTRA_ARGS="-DCMAKE_SYSTEM_NAME=iOS -DGEODE_TARGET_PLATFORM=iOS"
         fi
         if [ "${{ inputs.use-lto }}" = "true" ]; then
           CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"

--- a/action.yml
+++ b/action.yml
@@ -220,8 +220,9 @@ runs:
         else
           echo "cloning diff geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
-          mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
-          mv "${{ github.workspace }}/nightly-bin/*" "${{ github.workspace }}/geode-sdk-clone/bin/nightly/"
+          mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
+          ls "${{ github.workspace }}/nightly-bin"
+          mv "${{ github.workspace }}/nightly-bin" "${{ github.workspace }}/geode-sdk-clone/bin/nightly"
         fi
 
         # silly github actions wont refresh the env

--- a/action.yml
+++ b/action.yml
@@ -211,6 +211,8 @@ runs:
           echo "cloning ios geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
+          stupid=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[]')
+          echo "$stupid"
           dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
           echo "nightly dl url: $dl_url"
           curl -L "$dl_url" -o "geode-ios.zip" && unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly" && rm "geode-ios.zip"

--- a/action.yml
+++ b/action.yml
@@ -195,14 +195,6 @@ runs:
       with:
         version: ${{ inputs.cli }}
 
-    - name: Download Geode SDK
-      if: steps.platform.outputs.target_id == 'ios'
-      uses: actions/checkout@v4
-      with:
-        repository: geode-catgirls/geode
-        ref: nightly
-        path: geode-sdk-clone
-
     - name: Download binaries
       if: steps.platform.outputs.target_id == 'ios'
       uses: robinraju/release-downloader@v1
@@ -225,6 +217,9 @@ runs:
 
         if [ "${{ steps.platform.outputs.target_id }}" != "ios" ]; then
           geode sdk install "${{ github.workspace }}/geode-sdk-clone"
+        else
+          echo "cloning diff geode"
+          git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
         fi
 
         # silly github actions wont refresh the env

--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,9 @@ runs:
           echo "cloning ios geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
-          dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
+          wah=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases)
+          echo "wah $wah"
+          dl_url=$(echo "$wah" | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
           echo "nightly dl url: $dl_url"
           curl -L "$dl_url" -o "geode-ios.zip" && unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly" && rm "geode-ios.zip"
         fi

--- a/action.yml
+++ b/action.yml
@@ -211,9 +211,7 @@ runs:
           echo "cloning ios geode"
           git clone https://github.com/geode-catgirls/geode -b nightly "${{ github.workspace }}/geode-sdk-clone"
           mkdir -p "${{ github.workspace }}/geode-sdk-clone/bin"
-          wah=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases)
-          echo "wah $wah"
-          dl_url=$(echo "$wah" | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
+          dl_url=$(curl -s https://api.github.com/repos/geode-catgirls/geode/releases | jq '.[] | select(.tag_name=="nightly").assets[] | select(.name|endswith("-ios.zip")).browser_download_url' -r)
           echo "nightly dl url: $dl_url"
           curl -L "$dl_url" -o "geode-ios.zip" && unzip "geode-ios.zip" -d "${{ github.workspace }}/geode-sdk-clone/bin/nightly" && rm "geode-ios.zip"
         fi

--- a/combine/action.yml
+++ b/combine/action.yml
@@ -61,6 +61,9 @@ runs:
           if [ -f "./artifacts/geode-build-android64/$mod" ]; then
             PACKAGE_ARGS="$PACKAGE_ARGS ./artifacts/geode-build-android64/$mod"
           fi
+          if [ -f "./artifacts/geode-build-ios/$mod" ]; then
+            PACKAGE_ARGS="$PACKAGE_ARGS ./artifacts/geode-build-ios/$mod"
+          fi
           ARG_LIST=($PACKAGE_ARGS)
           # why does it merge into the first one instead of just an output..
           FIRST="${ARG_LIST[0]}"
@@ -85,6 +88,12 @@ runs:
       if: ${{ inputs.delete-artifacts }}
       with:
           name: geode-build-mac
+          failOnError: false
+
+    - uses: geekyeggo/delete-artifact@v5
+      if: ${{ inputs.delete-artifacts }}
+      with:
+          name: geode-build-ios
           failOnError: false
 
     - uses: geekyeggo/delete-artifact@v5

--- a/examples/multi-platform.yml
+++ b/examples/multi-platform.yml
@@ -18,6 +18,10 @@ jobs:
         - name: macOS
           os: macos-latest
 
+        - name: iOS
+          os: macos-latest
+          target: iOS
+
         - name: Android32
           os: ubuntu-latest
           target: Android32

--- a/examples/multi-platform.yml
+++ b/examples/multi-platform.yml
@@ -18,10 +18,6 @@ jobs:
         - name: macOS
           os: macos-latest
 
-        - name: iOS
-          os: macos-latest
-          target: iOS
-
         - name: Android32
           os: ubuntu-latest
           target: Android32


### PR DESCRIPTION
todo:
- [x] get mods to build
- [x] fix combine
- [x] use geode prebuilt binaries ~~(pending geode build action)~~
- [x] cleanup
  - [x] get rid of GH_PAT stuff
  - [x] revert to textureldr for test (after [textureldr#54](https://github.com/geode-sdk/textureldr/pull/54) is merged)
  - [x] make the whole thing not based on workarounds
  - [x] remove custom repo downloading stuff once Geode sapphire is merged upstream
  - [x] stop forcing nightly builds on ios