### PR TITLE
Fix false mod.json parsing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -216,7 +216,7 @@ runs:
           geode sdk update stable
           geode sdk install-binaries --platform ${{ steps.platform.outputs.target_id }}
         elif [ "${{ inputs.sdk }}" == "given" ]; then
-          export MOD_JSON_PATH=$(find . -name "mod.json" -not -path "./geode-sdk-clone/*" -print -quit)
+          export MOD_JSON_PATH=$(find . -name "mod.json" -not -path "./geode-sdk-clone/*" -print | sort -r | head -n 1)
           export TARGET_GEODE_VERSION=$(jq -r '.geode' $MOD_JSON_PATH)
           echo "Updating to version $TARGET_GEODE_VERSION from $MOD_JSON_PATH"
           geode sdk update "$TARGET_GEODE_VERSION"


### PR DESCRIPTION
Attempts to fix an issue found here: https://github.com/EclipseMenu/EclipseMenu/actions/runs/11653178834/job/32445286287

The `find` command was taking the `mod.json` from `gd-imgui-cocos` subdirectory found in `cpm-cache`, but that mod.json contained another geode version. This fix makes it take the closest mod.json to the current directory.